### PR TITLE
USB host detection improvements

### DIFF
--- a/Inc/USB/usbd_desc.h
+++ b/Inc/USB/usbd_desc.h
@@ -68,7 +68,7 @@
 /* USER CODE BEGIN EXPORTED_DEFINES */
 // XXX USB Firmware revision, interface names, VID and PIDs
 #define USB_DEVICE_MAJOR_VERSION                (0x02)
-#define USB_DEVICE_MINOR_VERSION                (0x04) // these are both BCD, e.g. 0x12 means .12
+#define USB_DEVICE_MINOR_VERSION                (0x05) // these are both BCD, e.g. 0x12 means .12
 #define USBD_VID                                (0x0483)
 #define DEVICE_MODE_PID_TBP                     (0x6F02u)
 #define DEVICE_MODE_PID_PARALLEL_DIGITIZER      (0x2F04u)


### PR DESCRIPTION
AXPB009 will now continually look for a USB host even after deciding there isn't one present.

This prevents the bridge from incorrectly deciding too early that no USB host is present if the USB cable is connected slowly (i.e. power is supplied a considerable time before the data pins).